### PR TITLE
integrate api for znodelist

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -25,6 +25,7 @@ var EventEmitter = require('events').EventEmitter;
 var RichListStorage = require('./richlist/storage/mongo');
 var MongoClient = require('mongodb').MongoClient;
 var SigmaStatusController = require('./sigmastatus');
+var ZNodeController = require('./znode');
 
 /**
  * A service for Bitcore to enable HTTP routes to query information about the blockchain.
@@ -76,7 +77,7 @@ var InsightAPI = function (options) {
     this.richListController = new RichListController({ node: this.node, storage: this.richListStorage });
     this.services.push(this.richListController);
 
-    this.sigmaStatusController = new SigmaStatusController({node: this.node, connection_params: options.postgres_db});
+    this.sigmaStatusController = new SigmaStatusController({ node: this.node, connection_params: options.postgres_db });
 };
 
 InsightAPI.dependencies = ['bitcoind', 'web'];
@@ -183,13 +184,13 @@ InsightAPI.prototype.setupRoutes = function (app) {
     });
     var logFormat = ':remote-forward-addr ":method :url" :status :res[content-length] :response-time ":user-agent" ';
     var logStream = this.createLogInfoStream();
-    app.use(morgan(logFormat, {stream: logStream}));
+    app.use(morgan(logFormat, { stream: logStream }));
 
     //Enable compression
     app.use(compression());
 
     //Enable urlencoded data
-    app.use(bodyParser.urlencoded({extended: true}));
+    app.use(bodyParser.urlencoded({ extended: true }));
 
     //Enable CORS
     app.use(function (req, res, next) {
@@ -226,7 +227,7 @@ InsightAPI.prototype.setupRoutes = function (app) {
     app.get('/block-index/:height', this.cacheShort(), blocks.blockIndex.bind(blocks));
     app.param('height', blocks.blockIndex.bind(blocks));
 
-	// Rich list routes
+    // Rich list routes
     app.get('/richlist', this.cacheShort(), this.richListController.list.bind(this.richListController));
 
     // Transaction routes
@@ -271,6 +272,12 @@ InsightAPI.prototype.setupRoutes = function (app) {
     var utils = new UtilsController(this.node);
     app.get('/utils/estimatefee', utils.estimateFee.bind(utils));
 
+    // ZelNode route
+    var znodes = new ZNodeController(this.node);
+    app.get('/znodes/listznodes', znodes.listZNodes.bind(utils));
+    app.get('/znodes/listznodesarray/:filter', znodes.listZNodesFilter.bind(utils));
+    app.post('/znodes/listznodesarray', znodes.listZNodesFilter.bind(utils));
+
     // Currency
     var currency = new CurrencyController({
         node: this.node,
@@ -280,13 +287,13 @@ InsightAPI.prototype.setupRoutes = function (app) {
 
     // Zerocoin
     var zerocoin = new ZerocoinController(this.node);
-    app.get('/zerocoin/gettotalzeromint',  zerocoin.gettotalzeromint.bind(zerocoin));
+    app.get('/zerocoin/gettotalzeromint', zerocoin.gettotalzeromint.bind(zerocoin));
     app.get('/zerocoin/gettotalzerospend', zerocoin.gettotalzerospend.bind(zerocoin));
     app.get('/zerocoin/getrealsupply', zerocoin.getrealsupply.bind(zerocoin));
     app.get('/zerocoin/getzerominttxs', zerocoin.getzerominttxs.bind(zerocoin));
     app.get('/zerocoin/getzerospendtxs', zerocoin.getzerospendtxs.bind(zerocoin));
     app.get('/sigma/gettotalsigmamint', zerocoin.gettotalsigmamint.bind(zerocoin));
-    app.get('/sigma/gettotalsigmaspend',zerocoin.gettotalsigmaspend.bind(zerocoin));
+    app.get('/sigma/gettotalsigmaspend', zerocoin.gettotalsigmaspend.bind(zerocoin));
     app.get('/sigma/getrealsupply', zerocoin.getsigmarealsupply.bind(zerocoin));
 
     // Extended
@@ -297,7 +304,7 @@ InsightAPI.prototype.setupRoutes = function (app) {
     app.get('/sigmastatus', this.sigmaStatusController.getSigmaStatus.bind(this.sigmaStatusController));
 
 
-  // Not Found
+    // Not Found
     app.use(function (req, res) {
         res.status(404).jsonp({
             status: 404,

--- a/lib/index.js
+++ b/lib/index.js
@@ -275,7 +275,7 @@ InsightAPI.prototype.setupRoutes = function (app) {
     // ZelNode route
     var znodes = new ZNodeController(this.node);
     app.get('/znodes/listznodes', znodes.listZNodes.bind(utils));
-    app.get('/znodes/listznodesarray/:filter', znodes.listZNodesFilter.bind(utils));
+    app.get('/znodes/listznodesarray/:filter?', znodes.listZNodesFilter.bind(utils));
     app.post('/znodes/listznodesarray', znodes.listZNodesFilter.bind(utils));
 
     // Currency

--- a/lib/znode.js
+++ b/lib/znode.js
@@ -1,0 +1,113 @@
+'use strict';
+
+var Common = require('./common');
+
+function ZNodeController(node) {
+  this.node = node;
+  this.common = new Common({ log: this.node.log });
+}
+
+// looks like i need to have it in separate call as was causing issues
+ZNodeController.prototype.listZNodes = function (req, res) {
+  this.node.services.bitcoind.evoznodelist(function (err, response) {
+    if (err) {
+      res.jsonp(err);
+    }
+    res.jsonp(response);
+  });
+};
+
+ZNodeController.prototype.listZNodesFilter = function (req, res) {
+  var filter = req.body.filter || req.params.filter || req.query.filter;
+  this.node.services.bitcoind.evoznodelist(function (err, response) {
+    if (err) {
+      res.jsonp(err);
+    }
+    try {
+      const keys = Object.keys(response.result);
+      const znodes = [];
+      keys.forEach((key) => {
+        const selectedNode = response.result[key];
+        const znode = {
+          collateral: key,
+          txhash: key.split(",")[0].substr(10),
+          outidx: key.split(", ")[1].slice(0, -1),
+          ip: selectedNode.address.split(":").slice(0, -1).join(''),
+          proTxHash: selectedNode.proTxHash,
+          address: selectedNode.address,
+          payee: selectedNode.payee,
+          status: selectedNode.status,
+          lastpaidtime: selectedNode.lastpaidtime,
+          lastpaidblock: selectedNode.lastpaidblock,
+          owneraddress: selectedNode.owneraddress,
+          votingaddress: selectedNode.votingaddress,
+          collateraladdress: selectedNode.collateraladdress,
+          pubkeyoperator: selectedNode.pubkeyoperator,
+        }
+        znodes.push(znode);
+      });
+      if (!filter) {
+        res.jsonp({
+          result: znodes,
+          error: response.error,
+          id: response.id
+        });
+      } else if (filter.includes(',')) {
+        const znodelist = znodes;
+        // comma separated list of collateralHash-collateralIndex, collateralHash-collateralIndex or more filters
+        const collateralsInInterest = filter.split(',');
+        let goodZNodes = [];
+        collateralsInInterest.forEach((interestedFilter) => {
+          if (interestedFilter.includes('-')) {
+            const txhash = interestedFilter.split('-')[0];
+            const outidx = interestedFilter.split('-')[1];
+            const goodZNodeList = znodelist.filter((znode) => (znode.txhash === txhash && znode.outidx === outidx))
+            if (goodZNodeList.length > 0) {
+              goodZNodes = goodZNodes.concat(goodZNodeList);
+            }
+          } else {
+            const goodZNodeList = znodelist.filter((znode) => JSON.stringify(znode).includes(interestedFilter))
+            if (goodZNodeList.length > 0) {
+              goodZNodes = goodZNodes.concat(goodZNodeList);
+            }
+          }
+        })
+        const znodelistToRespond = [...new Set(goodZNodes)];
+        res.jsonp({
+          result: znodelistToRespond,
+          error: response.error,
+          id: response.id
+        })
+      } else if (filter.includes('-')) {
+        const znodelist = znodes;
+        // scneario for just one znode
+        let goodZNodes = [];
+        const txhash = filter.split('-')[0];
+        const outidx = filter.split('-')[1];
+        const goodZNodeList = znodelist.filter((znode) => (znode.txhash === txhash && znode.outidx === outidx))
+        if (goodZNodeList.length > 0) {
+          goodZNodes = goodZNodes.concat(goodZNodeList);
+        }
+        const znodelistToRespond = [...new Set(goodZNodes)];
+        res.jsonp({
+          result: znodelistToRespond,
+          error: response.error,
+          id: response.id
+        })
+      } else {
+        const filteredList = znodes.filter(function (znode) {
+          return JSON.stringify(znode).includes(filter);
+        })
+        res.jsonp({
+          result: filteredList,
+          error: response.error,
+          id: response.id
+        })
+      }
+    } catch (error) {
+      res.jsonp(error)
+    }
+  });
+};
+
+module.exports = ZNodeController;


### PR DESCRIPTION
Adds following api calls using evoznodelist

GET /znodes/listznodes - standard daemon output
GET /znodes/listznodesarray/:filter? - makes an array from standard daemon output and add filtering options to it. Furthermore adds txhash, outidx and ip (without port).
POST /znodes/listznodesarray - same as GET but filter can be supplied with POST method which is useful if filter is long

These methods are useful especially for ZelCore and surely for other services as well that want to interact with ZNodes.
Live example at https://explorer.zcoin.zelcore.io/api/znodes/listznodesarray