### PR TITLE
Fix insertMany exception when empty array is used

### DIFF
--- a/lib/richlist/storage/mongo.js
+++ b/lib/richlist/storage/mongo.js
@@ -191,13 +191,22 @@ class MongoStorage {
             }
         }
 
+        const insertManyCollection = (collection, data) => {
+            if(data.length === 0) {
+                return Promise.resolve()
+            }
+            // insertMany fails when data is empty array 
+            // (node:1) UnhandledPromiseRejectionWarning: MongoError: Invalid Operation, no operations specified
+            return collection.insertMany(data)
+        }
+
         // insert documents
-        return this.transactions.insertMany(txs.map(tx => ({
+        return insertManyCollection(this.transactions, txs.map(tx => ({
             hash: tx.hash,
             locktime: tx.locktime,
             version: tx.version
         }))).then(() => {
-            return this.outputs.insertMany(outputs);
+            return insertManyCollection(this.outputs, outputs);
         }).then(() => this.blocks.insertOne({
             hash: block.hash,
             height: block.height,


### PR DESCRIPTION
I have been running insight node with api and ui in docker past two days and suddenly it crashed with out of memory error
```
[2021-11-17T01:50:46.076Z] info: Blocks scanned: 154500
[2021-11-17T01:52:42.321Z] info: Blocks scanned: 154600
[2021-11-17T01:54:52.162Z] info: Blocks scanned: 154700
[2021-11-17T01:57:46.424Z] info: Blocks scanned: 154800
[2021-11-17T02:00:35.933Z] info: Blocks scanned: 154900
[2021-11-17T02:03:24.923Z] info: Blocks scanned: 155000
[2021-11-17T02:05:52.203Z] info: Blocks scanned: 155100

<--- Last few GCs --->

[1:0x3898930] 35525315 ms: Mark-sweep 1355.3 (1444.1) -> 1355.3 (1444.1) MB, 306.3 / 0.0 ms  allocation failure GC in old space requested
[1:0x3898930] 35525713 ms: Mark-sweep 1355.3 (1444.1) -> 1355.3 (1441.1) MB, 353.1 / 0.0 ms  last resort GC in old space requested
[1:0x3898930] 35526066 ms: Mark-sweep 1355.3 (1441.1) -> 1355.3 (1441.1) MB, 352.5 / 0.0 ms  last resort GC in old space requested


<--- JS stacktrace --->

==== JS stack trace =========================================

Security context: 0x37b9fa1255e9 <JSObject>
    2: onread [net.js:563] [bytecode=0x133131036011 offset=0](this=0x1f3f0a02dc29 <TCP map = 0x173cf70f1ee1>,nread=45,buffer=0x119890e72d19 <Uint8Array map = 0x173cf70ed601>)

==== Details ================================================

[2]: onread [net.js:563] [bytecode=0x133131036011 offset=0](this=0x1f3f0a02dc29 <TCP map = 0x173cf70f1ee1>,nread=45,buffer=0x119890e72d19 <Uint8Array map = 0x1...

FATAL ERROR: CALL_AND_RETRY_LAST Allocation failed - JavaScript heap out of memory
 1: node::Abort() [bitcore]
 2: 0x8d05bc [bitcore]
 3: v8::Utils::ReportOOMFailure(char const*, bool) [bitcore]
 4: v8::internal::V8::FatalProcessOutOfMemory(char const*, bool) [bitcore]
 5: v8::internal::Factory::NewCode(v8::internal::CodeDesc const&, unsigned int, v8::internal::Handle<v8::internal::Object>, bool, int) [bitcore]
 6: v8::internal::CodeGenerator::MakeCodeEpilogue(v8::internal::TurboAssembler*, v8::internal::EhFrameWriter*, v8::internal::CompilationInfo*, v8::internal::Handle<v8::internal::Object>) [bitcore]
 7: v8::internal::compiler::CodeGenerator::FinalizeCode() [bitcore]
 8: v8::internal::compiler::PipelineImpl::FinalizeCode() [bitcore]
 9: v8::internal::compiler::PipelineCompilationJob::FinalizeJobImpl() [bitcore]
10: v8::internal::Compiler::FinalizeCompilationJob(v8::internal::CompilationJob*) [bitcore]
11: v8::internal::OptimizingCompileDispatcher::InstallOptimizedFunctions() [bitcore]
12: v8::internal::StackGuard::HandleInterrupts() [bitcore]
13: v8::internal::Runtime_StackGuard(int, v8::internal::Object**, v8::internal::Isolate*) [bitcore]
14: 0x3eada1a842fd
```

When docker restarted container i got error on the start 

```
wait-for-it.sh: waiting 15 seconds for mongo:27017
wait-for-it.sh: mongo:27017 is available after 0 seconds
fullConfig.path = /app/bitcore-node-zcoin.json

[2021-11-17T02:07:29.288Z] info: Using config: /app/bitcore-node-zcoin.json
[2021-11-17T02:07:29.289Z] info: Using network: livenet
[2021-11-17T02:07:29.289Z] info: Starting bitcoind
[2021-11-17T02:07:29.522Z] info: Zcoin Daemon Ready
[2021-11-17T02:07:29.523Z] info: Starting web
[2021-11-17T02:07:29.544Z] info: Starting insight-api-zcoin
(node:1) [MONGODB DRIVER] Warning: Current Server Discovery and Monitoring engine is deprecated, and will be removed in a future version. To use the new Server Discover and Monitoring engine, pass option { useUnifiedTopology: true } to the MongoClient constructor.
[2021-11-17T02:07:29.653Z] info: Starting insight-ui-zcoin
[2021-11-17T02:07:29.654Z] info: Bitcore Node ready
[2021-11-17T02:07:29.815Z] warn: ZMQ connection delay: tcp://172.27.0.10:28888
(node:1) UnhandledPromiseRejectionWarning: MongoError: Invalid Operation, no operations specified
    at Function.create (/app/insight/node_modules/mongodb/lib/core/error.js:59:12)
    at toError (/app/insight/node_modules/mongodb/lib/utils.js:130:22)
    at OrderedBulkOperation.bulkExecute (/app/insight/node_modules/mongodb/lib/bulk/common.js:1210:31)
    at OrderedBulkOperation.execute (/app/insight/node_modules/mongodb/lib/bulk/common.js:1240:22)
    at BulkWriteOperation.execute (/app/insight/node_modules/mongodb/lib/operations/bulk_write.js:67:10)
    at InsertManyOperation.execute (/app/insight/node_modules/mongodb/lib/operations/insert_many.js:37:24)
    at callback (/app/insight/node_modules/mongodb/lib/operations/execute_operation.js:72:19)
    at maybePromise (/app/insight/node_modules/mongodb/lib/utils.js:692:3)
    at executeOperation (/app/insight/node_modules/mongodb/lib/operations/execute_operation.js:34:10)
    at Collection.insertMany (/app/insight/node_modules/mongodb/lib/collection.js:557:10)
(node:1) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
(node:1) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
[2021-11-17T02:07:29.817Z] info: ZMQ connected to: tcp://172.27.0.10:28888
```

This happened in the middle of syncing block height 155146 and triggered execution path

https://github.com/firoorg/insight-api-zcoin/blob/b5530b48f36db60079064fdc6c49c4c3b71e6925/lib/richlist/controller.js#L149

(verified after sprinkling `console.log()` everywhere)
