### PR TITLE
Cruxpool-general

### DIFF
--- a/pools.json
+++ b/pools.json
@@ -391,7 +391,7 @@
         "poolName": "Cruxpool",
         "url": "https://www.cruxpool.com/",
         "searchStrings": [
-            "/Cruxpool-eu8/"
+            "Cruxpool"
         ]
     }
 ]


### PR DESCRIPTION
Cruxpool uses more than one stratum in its coinbase identifier. This PR changes the identifier in insight to ensure all stratums are covered.